### PR TITLE
Add JSON Content-Type

### DIFF
--- a/ESP8266_Simple.cpp
+++ b/ESP8266_Simple.cpp
@@ -440,7 +440,7 @@ byte ESP8266_Simple::serveHttpRequest()
   if(!this->espSerial->available()) return ESP8266_OK; // Nothing to do
 
   char cmdBuffer[64];
-  char hdrBuffer[64];     
+  char hdrBuffer[128];     
   
   char dataBuffer[this->httpServerMaxBufferSize];
   int  requestLength;
@@ -477,9 +477,11 @@ byte ESP8266_Simple::serveHttpRequest()
     // If it's not a raw response, make some headers
     if(!(httpStatusCodeAndType & ESP8266_RAW))
     {
-      strncpy_P(hdrBuffer, PSTR("HTTP/1.0 "), sizeof(hdrBuffer)-1);
+      strncpy_P(hdrBuffer, PSTR("HTTP/1.1 "), sizeof(hdrBuffer)-1);
       itoa( httpStatusCodeAndType & 0x00FFFFFF,hdrBuffer+strlen(hdrBuffer), 10);
       strncpy_P(hdrBuffer+strlen(hdrBuffer), PSTR("\r\nContent-type: "), sizeof(hdrBuffer)-strlen(hdrBuffer)-1);
+
+      Serial.println(httpStatusCodeAndType & 0xFF000000, HEX);
       
       switch(httpStatusCodeAndType & 0xFF000000)
       {
@@ -489,8 +491,11 @@ byte ESP8266_Simple::serveHttpRequest()
           
         case ESP8266_TEXT:
           strncpy_P(hdrBuffer+strlen(hdrBuffer), PSTR("text/plain"), sizeof(hdrBuffer)-strlen(hdrBuffer)-1);
-          break;          
+          break;
 
+        case ESP8266_JSON:
+          strncpy_P(hdrBuffer+strlen(hdrBuffer), PSTR("application/json"), sizeof(hdrBuffer)-strlen(hdrBuffer)-1);
+          break;
       }
       strncpy_P(hdrBuffer + strlen(hdrBuffer), PSTR("\r\nContent-Length: "), sizeof(hdrBuffer) - strlen(hdrBuffer) - 1);
       itoa(strlen(dataBuffer), hdrBuffer + strlen(hdrBuffer), 10);

--- a/ESP8266_Simple.cpp
+++ b/ESP8266_Simple.cpp
@@ -480,8 +480,6 @@ byte ESP8266_Simple::serveHttpRequest()
       strncpy_P(hdrBuffer, PSTR("HTTP/1.1 "), sizeof(hdrBuffer)-1);
       itoa( httpStatusCodeAndType & 0x00FFFFFF,hdrBuffer+strlen(hdrBuffer), 10);
       strncpy_P(hdrBuffer+strlen(hdrBuffer), PSTR("\r\nContent-type: "), sizeof(hdrBuffer)-strlen(hdrBuffer)-1);
-
-      Serial.println(httpStatusCodeAndType & 0xFF000000, HEX);
       
       switch(httpStatusCodeAndType & 0xFF000000)
       {

--- a/ESP8266_Simple.h
+++ b/ESP8266_Simple.h
@@ -58,7 +58,8 @@
 
 #define ESP8266_HTML    0x01000000
 #define ESP8266_TEXT    0x02000000
-#define ESP8266_RAW     0x04000000
+#define ESP8266_JSON    0x04000000
+#define ESP8266_RAW     0x08000000
 
 #include "ESP8266_Serial.h"
 


### PR DESCRIPTION
hdrBuffer's size is increase. Because when I write "application/json" in content-type, hdrBuffer has buffer overflow. it make reset arduino.

And HTTP 1.0 doesn't have "application/json", so http version is increase to 1.1.

Thank you. :)